### PR TITLE
feat: add CORS for web dev support

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -13,6 +13,7 @@
         "@prisma/client": "^7.6.0",
         "@supabase/supabase-js": "^2.38.0",
         "@types/node": "^20.10.0",
+        "cors": "^2.8.6",
         "express": "^5.0.0",
         "helmet": "^7.1.0",
         "pg": "^8.20.0",
@@ -24,6 +25,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.11",
         "@types/pg": "^8.20.0",
@@ -2404,6 +2406,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
@@ -3760,6 +3772,23 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -6621,6 +6650,15 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,6 +35,7 @@
     "@prisma/client": "^7.6.0",
     "@supabase/supabase-js": "^2.38.0",
     "@types/node": "^20.10.0",
+    "cors": "^2.8.6",
     "express": "^5.0.0",
     "helmet": "^7.1.0",
     "pg": "^8.20.0",
@@ -46,6 +47,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.11",
     "@types/pg": "^8.20.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, NextFunction } from 'express';
+import cors from 'cors';
 import helmet from 'helmet';
 import pinoHttp from 'pino-http';
 import { logger } from './lib/logger.js';
@@ -13,6 +14,18 @@ export const app = express();
 
 // Trust proxy - required for getting real IP behind Railway load balancer
 app.set('trust proxy', 1);
+
+// CORS — allow Expo web dev server and any localhost origin
+app.use(cors({
+  origin: (origin, cb) => {
+    if (!origin || origin.includes('localhost') || origin.includes('127.0.0.1')) {
+      cb(null, true);
+    } else {
+      cb(null, false);
+    }
+  },
+  credentials: true,
+}));
 
 // Security middleware
 app.use(helmet());


### PR DESCRIPTION
## Summary
- Adds cors middleware to Express app
- Allows requests from localhost/127.0.0.1 origins (Expo web dev server)
- Required for web-based UI testing via expo start --web

?? Generated with [Claude Code](https://claude.com/claude-code)